### PR TITLE
Fix to give aspnet the correct assemblyName

### DIFF
--- a/src/WorldDomination.SimpleHosting/Program.cs
+++ b/src/WorldDomination.SimpleHosting/Program.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using System.Reflection;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
@@ -189,6 +190,8 @@ namespace WorldDomination.SimpleHosting
                         // (Pro Tip: this is a great way to add logging, to Startup.cs !!! YES!!!! )
                         //webBuilder.UseStartup(c => new TStartup(c));
                         webBuilder.UseStartup(context => options.StartupActivation(context, logger));
+                        var startupAssemblyName = options.StartupActivation.GetMethodInfo().DeclaringType!.GetTypeInfo().Assembly.GetName().Name;
+                        webBuilder.UseSetting(WebHostDefaults.ApplicationKey, startupAssemblyName);
                     }
                 });
 


### PR DESCRIPTION
This looks like what is happening inside that method, so this just clobbers what they store with the correct assembly name. Based on https://github.com/dotnet/aspnetcore/blob/3e9ae8e5eee2930da0096ab4ca4976f5938df648/src/Hosting/Hosting/src/WebHostBuilderExtensions.cs#L85 .