### PR TITLE
Update package to use embedded symbols

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,12 @@
+<Project>
+
+  <PropertyGroup>
+    <TargetFramework>net5.0</TargetFramework>
+    <LangVersion>latest</LangVersion>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(CI)' == 'true'">
+    <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
+  </PropertyGroup>
+
+</Project>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,8 +8,8 @@ pull_requests:
 init:
   - ps: |
       if ($env:APPVEYOR_REPO_TAG -eq $TRUE -and $env:APPVEYOR_REPO_BRANCH -eq 'master')
-      { 
-          Write-Host " !! Commit is Tagged and branch is 'master' - forcing build version to tag-value." -ForegroundColor Red; 
+      {
+          Write-Host " !! Commit is Tagged and branch is 'master' - forcing build version to tag-value." -ForegroundColor Red;
           Update-AppveyorBuild -Version "$env:APPVEYOR_REPO_TAG_NAME"
       }
       iex ((new-object net.webclient).DownloadString('https://gist.githubusercontent.com/PureKrome/0f79e25693d574807939/raw/f5b40256fc2ca77d49f1c7773d28406152544c1e/appveyor-build-info.ps'))
@@ -53,7 +53,7 @@ after_test:
           Invoke-WebRequest -Uri 'https://codecov.io/bash' -OutFile codecov.sh
           bash codecov.sh -s './CodeCoverageResults/' -f '*.xml' -Z
       }
-      
+
       if ($env:CONFIGURATION -eq 'Release')
       {
           dotnet pack -c $env:CONFIGURATION --no-build /p:Version=$env:APPVEYOR_BUILD_VERSION /p:ContinuousIntegrationBuild=true src/WorldDomination.SimpleHosting/WorldDomination.SimpleHosting.csproj
@@ -62,9 +62,6 @@ after_test:
 artifacts:
   - path: '**\*.nupkg'
     name: nuget-packages
-    type: NuGetPackage
-  - path: '**\*.snupkg'
-    name: nuget-symbols
     type: NuGetPackage
 
 deploy:

--- a/src/WorldDomination.SimpleHosting.SampleHostedServiceApplication/WorldDomination.SimpleHosting.SampleHostedServiceApplication.csproj
+++ b/src/WorldDomination.SimpleHosting.SampleHostedServiceApplication/WorldDomination.SimpleHosting.SampleHostedServiceApplication.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Worker">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
     <UserSecretsId>dotnet-SampleBackgroundTask-AF705853-E47B-47BB-AECC-3BD0F2F2AA7A</UserSecretsId>
   </PropertyGroup>
 
@@ -12,4 +11,5 @@
   <ItemGroup>
     <ProjectReference Include="..\WorldDomination.SimpleHosting\WorldDomination.SimpleHosting.csproj" />
   </ItemGroup>
+
 </Project>

--- a/src/WorldDomination.SimpleHosting.SampleWebApplication.Tests/WorldDomination.SimpleHosting.SampleWebApplication.Tests.csproj
+++ b/src/WorldDomination.SimpleHosting.SampleWebApplication.Tests/WorldDomination.SimpleHosting.SampleWebApplication.Tests.csproj
@@ -1,8 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
-
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/src/WorldDomination.SimpleHosting.SampleWebApplication/WorldDomination.SimpleHosting.SampleWebApplication.csproj
+++ b/src/WorldDomination.SimpleHosting.SampleWebApplication/WorldDomination.SimpleHosting.SampleWebApplication.csproj
@@ -1,9 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
-  <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
-  </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
   </ItemGroup>

--- a/src/WorldDomination.SimpleHosting/WorldDomination.SimpleHosting.csproj
+++ b/src/WorldDomination.SimpleHosting/WorldDomination.SimpleHosting.csproj
@@ -1,8 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
-    <LangVersion>latest</LangVersion>
     <PackageId>WorldDomination.SimpleHosting</PackageId>
     <Authors>Pure Krome</Authors>
     <Company>World Domination Technologies</Company>
@@ -14,7 +12,9 @@
     <PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
     <RepositoryUrl>https://github.com/PureKrome/SimpleHosting</RepositoryUrl>
     <RepositoryType>.net c# .net-core</RepositoryType>
-    <PackageTags>.net dotnet c# netcore aspnetcore aspnet-core hosting world-domination unicorn magicalunicorn magical-unicorn</PackageTags> 
+    <PackageTags>.net dotnet c# netcore aspnetcore aspnet-core hosting world-domination unicorn magicalunicorn magical-unicorn</PackageTags>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>embedded</DebugType>
 
     <!-- Microsoft.NET.Sdk.Web aren't ment for packaging into dll's. You usually publish a website.
          As such, we need to specify that this is ok to do -->
@@ -23,11 +23,8 @@
     <!-- Source Link. REF: https://github.com/dotnet/sourcelink -->
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
-    <IncludeSymbols>true</IncludeSymbols>
-    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <PackageIcon>icon.jpg</PackageIcon>
     <PackageIconUrl />
-
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This updates the package to use embedded symbols instead of a `snupkg` which is required to use the new [embedded readme](https://devblogs.microsoft.com/nuget/add-a-readme-to-your-nuget-package/) feature (see [this](https://www.nuget.org/packages/TailwindCssTagHelpers/) for an example) which will come in a separate PR unless you'd like it in this one.